### PR TITLE
Improve checking if sidebar exists and fix some notices

### DIFF
--- a/class-widget-data.php
+++ b/class-widget-data.php
@@ -261,7 +261,7 @@ class Widget_Data {
 
 			foreach ( $import_widgets as $import_widget ) :
 				//if the sidebar exists
-				if ( isset( $current_sidebars[$import_sidebar] ) ) :
+				if ( array_key_exists( $import_sidebar, $current_sidebars ) ) :
 					$title = trim( substr( $import_widget, 0, strrpos( $import_widget, '-' ) ) );
 					$index = trim( substr( $import_widget, strrpos( $import_widget, '-' ) + 1 ) );
 					$current_widget_data = get_option( 'widget_' . $title );
@@ -281,8 +281,8 @@ class Widget_Data {
 						$new_widgets[$title]['_multiwidget'] = $multiwidget;
 					} else {
 						$current_widget_data[$new_index] = $widget_data[$title][$index];
-						$current_multiwidget = $current_widget_data['_multiwidget'];
-						$new_multiwidget = isset($widget_data[$title]['_multiwidget']) ? $widget_data[$title]['_multiwidget'] : false;
+						$current_multiwidget = array_key_exists('_multiwidget', $current_widget_data) ? $current_widget_data['_multiwidget'] : false;
+						$new_multiwidget = array_key_exists('_multiwidget', $widget_data[$title]) ? $widget_data[$title]['_multiwidget'] : false;
 						$multiwidget = ($current_multiwidget != $new_multiwidget) ? $current_multiwidget : 1;
 						unset( $current_widget_data['_multiwidget'] );
 						$current_widget_data['_multiwidget'] = $multiwidget;


### PR DESCRIPTION
Hi,

First of all, great plugin! I'm glad that something like this exists in WP since I come from other CMS :)
Anyway, problems that I've had is that sometimes `$current_sidebars` contains keys that have `null` value which while asking 
`isset($current_sidebars[$import_sidebar])` 
returns `false`
Instead, should be asked whether that key exists in an array and then importer will continue working normally.
Another similar issue was with key `'_multiwidget'` which doesn't always exist (I've tried exporter few times and it doesn't always export that particular key) and there is no proper check, it's just set. That can cause warnings which additionally triggers `"Headers already sent"` if it's on development server.
I'd like to mention that I am using latest WordPress 4.0 on Mac OS, PHP 5.4.24
It's my first pull request so please let me know if I did something wrong or you need more information.

Thanks!
